### PR TITLE
Add CI workflow for tests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r app/requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest -q


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Python tests on pushes and pull requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b6b686480832083c0e559f8822c43