### PR TITLE
Support multiple document types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # llama3-gui
 
-This project provides a minimal interface for querying PDFs using the LLaMA 3 model via [Ollama](https://ollama.ai/). It runs entirely locally and requires no external API keys.
+This project provides a minimal interface for querying local documents using the LLaMA 3 model via [Ollama](https://ollama.ai/). It runs entirely locally and requires no external API keys.
 
 ## Quick start
 
 1. Install [Docker](https://docs.docker.com/get-docker/) and `docker-compose`.
 2. Run `docker-compose up --build` to start the Ollama server and Streamlit app.
-3. Open `http://localhost:8501` in your browser and upload a PDF. If the file is password protected, supply the password when prompted.
-4. Use the chat box at the bottom to ask questions about the PDF. Messages appear in a chat-style layout and the sidebar lets you reset or clear history.
+3. Open `http://localhost:8501` in your browser and upload a PDF, DOCX, TXT or PPTX file. If you upload a PDF that is password protected, supply the password when prompted.
+4. Use the chat box at the bottom to ask questions about the document. Messages appear in a chat-style layout and the sidebar lets you reset or clear history.
 
 The app keeps a simple history of your questions and answers for the current session. The sidebar provides buttons to start a fresh chat or clear the existing conversation.
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,10 @@
 import os
 import tempfile
 import streamlit as st
-from utils import load_pdf_with_password, create_vector_store, get_qa_chain
+from utils import load_document, create_vector_store, get_qa_chain
 
-st.set_page_config(page_title="🔐 LLaMA 3 PDF Q&A", layout="wide")
-st.title("🔐 LLaMA 3 PDF Q&A with Password Support")
+st.set_page_config(page_title="🔐 LLaMA 3 Document Q&A", layout="wide")
+st.title("🔐 LLaMA 3 Document Q&A with Password Support")
 
 # ─── Sidebar controls ────────────────────────────────────────────────────
 with st.sidebar:
@@ -21,17 +21,21 @@ if "history" not in st.session_state:
 if "qa" not in st.session_state:
     st.session_state.qa = None
 
-uploaded_file = st.file_uploader("Upload a PDF", type="pdf")
+uploaded_file = st.file_uploader(
+    "Upload a document",
+    type=["pdf", "docx", "txt", "pptx"],
+)
 password = st.text_input("Enter PDF password (if any)", type="password")
 
-if uploaded_file and st.button("Process PDF"):
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+if uploaded_file and st.button("Process document"):
+    ext = os.path.splitext(uploaded_file.name)[1]
+    with tempfile.NamedTemporaryFile(delete=False, suffix=ext) as tmp:
         tmp.write(uploaded_file.read())
         tmp_path = tmp.name
-    text = load_pdf_with_password(tmp_path, password)
+    text = load_document(tmp_path, password)
     os.unlink(tmp_path)
     if text:
-        st.success("✅ PDF loaded and parsed successfully.")
+        st.success("✅ Document loaded and parsed successfully.")
         vector_store = create_vector_store(text)
         st.session_state.qa = get_qa_chain(vector_store)
     else:
@@ -42,7 +46,7 @@ if st.session_state.qa:
         with st.chat_message(msg[0]):
             st.markdown(msg[1])
 
-    if prompt := st.chat_input("Ask a question about your PDF:"):
+    if prompt := st.chat_input("Ask a question about your document:"):
         with st.chat_message("user"):
             st.markdown(prompt)
         with st.spinner("Thinking…"):

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -5,3 +5,5 @@ faiss-cpu
 PyMuPDF
 ollama
 sentence-transformers
+python-docx
+python-pptx


### PR DESCRIPTION
## Summary
- allow loading DOCX, TXT and PPTX files in addition to PDFs
- update Streamlit UI to accept multiple file types
- add document loading helpers for new formats
- document the new behavior in README
- include python-docx and python-pptx in requirements

## Testing
- `python -m py_compile app/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b6bb3d9e4832087b95fd77303fa8c