### PR TITLE
Enable conversation memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project provides a minimal interface for querying local documents using the
 3. Open `http://localhost:8501` in your browser and upload a PDF, DOCX, TXT or PPTX file. If you upload a PDF that is password protected, supply the password when prompted.
 4. Use the chat box at the bottom to ask questions about the document. Messages appear in a chat-style layout and the sidebar lets you reset or clear history.
 
-The app keeps a simple history of your questions and answers for the current session. The sidebar provides buttons to start a fresh chat or clear the existing conversation.
+The app now maintains context between questions using a conversational retrieval chain with memory. The sidebar provides buttons to start a fresh chat or clear the existing conversation.
 
 ## Development
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -6,7 +6,8 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain.embeddings import SentenceTransformerEmbeddings
 from langchain.vectorstores import FAISS
 from langchain.llms import Ollama
-from langchain.chains import RetrievalQA
+from langchain.chains import ConversationalRetrievalChain
+from langchain.memory import ConversationBufferMemory
 from langchain.schema import Document
 
 
@@ -69,9 +70,14 @@ def create_vector_store(text: str) -> FAISS:
     return FAISS.from_documents(chunks, embeddings)
 
 
-def get_qa_chain(vector_store: FAISS) -> RetrievalQA:
-    """Set up a RetrievalQA chain using an Ollama LLaMA 3 model."""
+def get_qa_chain(vector_store: FAISS) -> ConversationalRetrievalChain:
+    """Return a conversational QA chain with memory using an Ollama LLaMA 3 model."""
     base_url = os.getenv("OLLAMA_BASE_URL", "http://ollama:11434")
     llm = Ollama(model="llama3", base_url=base_url)
-    return RetrievalQA.from_chain_type(llm=llm, retriever=vector_store.as_retriever())
+    memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
+    return ConversationalRetrievalChain.from_llm(
+        llm=llm,
+        retriever=vector_store.as_retriever(),
+        memory=memory,
+    )
 


### PR DESCRIPTION
## Summary
- add conversation memory using `ConversationBufferMemory`
- update README to reflect persistent conversation history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b71730a1c832087d0339d29d9e446