### PR TITLE
Fix memory output key for conversational chain

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -123,7 +123,11 @@ def get_qa_chain(
         temperature=temperature,
         num_predict=max_tokens,
     )
-    memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
+    memory = ConversationBufferMemory(
+        memory_key="chat_history",
+        return_messages=True,
+        output_key="answer",
+    )
     return ConversationalRetrievalChain.from_llm(
         llm=llm,
         retriever=vector_store.as_retriever(),


### PR DESCRIPTION
## Summary
- fix `ConversationBufferMemory` config so answer is stored in chat history

## Testing
- `python -m py_compile app/*.py`
- `ruff check --quiet .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b7e2d30e48320826da6cc431aa73f