### PR TITLE
Add UI help for temperature and max tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ The app now maintains context between questions using a conversational retrieval
 - A button to download your chat transcript.
 - Sliders to tweak model temperature and token limits.
 
+The temperature slider controls the randomness of the model's responses:
+higher values lead to more varied answers. The token limit sets the
+maximum length of each reply.
+
 ## Development
 
 The main functionality lives in `app/main.py` and helper functions in `app/utils.py`. Dependencies are listed in `app/requirements.txt`.

--- a/app/main.py
+++ b/app/main.py
@@ -25,8 +25,20 @@ with st.sidebar:
         st.session_state.history = []
     st.divider()
     st.header("Model")
-    temp = st.slider("Temperature", 0.0, 1.0, 0.1, step=0.05)
-    tokens = st.number_input("Max tokens", value=256, step=64)
+    temp = st.slider(
+        "Temperature",
+        0.0,
+        1.0,
+        0.1,
+        step=0.05,
+        help="Higher values generate more random output",
+    )
+    tokens = st.number_input(
+        "Max tokens",
+        value=256,
+        step=64,
+        help="Limits the length of the model's response",
+    )
     if st.session_state.get("history"):
         transcript = "\n".join(f"{r}: {m}" for r, m in st.session_state.history)
         st.download_button(


### PR DESCRIPTION
## Summary
- explain model temperature and token limits in README
- show tooltips for the temperature and max token widgets

## Testing
- `python -m py_compile app/*.py`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bed6d163083209951793332f2b9e1