### PR TITLE
Implement question clarification using conversation context

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from utils import (
     create_vector_store,
     get_qa_chain,
     summarize_text,
+    rewrite_question,
 )
 
 st.set_page_config(page_title="🔐 LLaMA 3 Document Q&A", layout="wide")
@@ -84,8 +85,9 @@ if st.session_state.qa:
     if prompt := st.chat_input("Ask a question about your document:"):
         with st.chat_message("user"):
             st.markdown(prompt)
+        clarified = rewrite_question(prompt, st.session_state.history)
         with st.spinner("Thinking…"):
-            result = st.session_state.qa.invoke({"question": prompt})
+            result = st.session_state.qa.invoke({"question": clarified})
             answer = result["answer"]
             docs = result.get("source_documents", [])
             if docs:

--- a/app/utils.py
+++ b/app/utils.py
@@ -139,3 +139,23 @@ def get_qa_chain(
         return_source_documents=True,
     )
 
+
+def rewrite_question(
+    question: str, history: list[tuple[str, str]] | None = None
+) -> str:
+    """Return a clarified version of ``question`` using conversation context."""
+    base_url = os.getenv("OLLAMA_BASE_URL", "http://ollama:11434")
+    llm = Ollama(model="llama3", base_url=base_url, temperature=0.0)
+    history_text = ""
+    if history:
+        history_text = "\n".join(f"{r}: {m}" for r, m in history[-6:])
+    prompt = (
+        "Rewrite the following user question to be clear and self contained."\
+        " Use the prior conversation for context if helpful.\n\n"\
+        f"History:\n{history_text}\n\nQuestion: {question}\n\nRewritten:"
+    )
+    try:
+        return llm.invoke(prompt).strip()
+    except Exception:
+        return question
+


### PR DESCRIPTION
## Summary
- clarify user questions before passing to the QA chain
- import new util `rewrite_question`
- add `rewrite_question` helper to use conversation history and LLaMA 3

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685befb6859c83209d1acadcca52fbc6