### PR TITLE
Update token limit default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The app now maintains context between questions using a conversational retrieval
 - Persistent search indexes for faster reuse.
 - Page references in answers when available.
 - A button to download your chat transcript.
-- Sliders to tweak model temperature and token limits.
+- Sliders to tweak model temperature and token limits (default 8192 tokens).
 
 The temperature slider controls the randomness of the model's responses:
 higher values lead to more varied answers. The token limit sets the

--- a/app/main.py
+++ b/app/main.py
@@ -36,7 +36,7 @@ with st.sidebar:
     )
     tokens = st.number_input(
         "Max tokens",
-        value=256,
+        value=8192,
         step=64,
         help="Limits the length of the model's response",
     )

--- a/app/utils.py
+++ b/app/utils.py
@@ -117,7 +117,7 @@ def create_vector_store(docs: list[Document], path: str) -> FAISS:
 def get_qa_chain(
     vector_store: FAISS,
     temperature: float = 0.1,
-    max_tokens: int = 256,
+    max_tokens: int = 8192,
 ) -> ConversationalRetrievalChain:
     """Return a conversational QA chain with memory using LLaMA 3."""
     base_url = os.getenv("OLLAMA_BASE_URL", "http://ollama:11434")


### PR DESCRIPTION
## Summary
- bump default tokens up to 8192
- note the default in the README

## Testing
- `python -m py_compile app/*.py`
- `ruff check --quiet .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bf24db31083209795b5c625917edd