### PR TITLE
Fix token limit slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The app now maintains context between questions using a conversational retrieval
 - Persistent search indexes for faster reuse.
 - Page references in answers when available.
 - A button to download your chat transcript.
-- Sliders to tweak model temperature and token limits (default 8192 tokens).
+- Sliders to tweak model temperature and token limits (up to 8192 tokens).
 
 The temperature slider controls the randomness of the model's responses:
 higher values lead to more varied answers. The token limit sets the

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from utils import (
     get_qa_chain,
     summarize_text,
     rewrite_question,
+    MAX_TOKENS,
 )
 
 st.set_page_config(page_title="🔐 LLaMA 3 Document Q&A", layout="wide")
@@ -36,7 +37,9 @@ with st.sidebar:
     )
     tokens = st.number_input(
         "Max tokens",
-        value=8192,
+        value=MAX_TOKENS,
+        max_value=MAX_TOKENS,
+        min_value=64,
         step=64,
         help="Limits the length of the model's response",
     )
@@ -54,7 +57,7 @@ if "history" not in st.session_state:
 if "qa" not in st.session_state:
     st.session_state.qa = None
 st.session_state.temperature = temp
-st.session_state.max_tokens = int(tokens)
+st.session_state.max_tokens = min(int(tokens), MAX_TOKENS)
 
 uploaded_files = st.file_uploader(
     "Upload documents",

--- a/app/utils.py
+++ b/app/utils.py
@@ -10,6 +10,9 @@ from langchain.chains import ConversationalRetrievalChain
 from langchain.memory import ConversationBufferMemory
 from langchain.schema import Document
 
+# Maximum number of tokens supported by the model.
+MAX_TOKENS = 8192
+
 
 def summarize_text(text: str) -> str:
     """Return a short summary of ``text`` using LLaMA 3."""
@@ -125,7 +128,7 @@ def get_qa_chain(
         model="llama3",
         base_url=base_url,
         temperature=temperature,
-        num_predict=max_tokens,
+        num_predict=min(max_tokens, MAX_TOKENS),
     )
     memory = ConversationBufferMemory(
         memory_key="chat_history",


### PR DESCRIPTION
## Summary
- keep responses within the model's 8192 token cap
- clarify README around token limits

## Testing
- `python -m py_compile app/*.py`
- `ruff check --quiet .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bf36b44648320a1cece58987a27fd