### PR TITLE
Add OCR support for PDF and PPT images

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The app now maintains context between questions using a conversational retrieval
 - Page references in answers when available.
 - A button to download your chat transcript.
 - Sliders to tweak model temperature and token limits (up to 8192 tokens).
+- Images embedded in PDFs and PowerPoint slides are OCR'd so their text can be
+  searched as well.
 
 The temperature slider controls the randomness of the model's responses:
 higher values lead to more varied answers. The token limit sets the
@@ -42,6 +44,9 @@ model and the app image downloads the required sentence-transformer embeddings.
 ```bash
 docker-compose build
 ```
+
+The Dockerfile installs the `tesseract-ocr` package so that text can be
+extracted from images. Build while online to fetch this dependency.
 
 After the build completes you can disconnect from the internet and start the
 stack normally:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ docker-compose build
 
 The Dockerfile installs the `tesseract-ocr` package so that text can be
 extracted from images. Build while online to fetch this dependency.
+If you run the tests directly on your host instead of through Docker,
+you'll need to install `tesseract-ocr` yourself:
+
+```bash
+sudo apt-get install -y tesseract-ocr libtesseract-dev
+```
 
 After the build completes you can disconnect from the internet and start the
 stack normally:

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,5 +1,12 @@
 FROM python:3.11-slim
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        tesseract-ocr \
+        libtesseract-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY requirements.txt ./

--- a/app/ocr_utils.py
+++ b/app/ocr_utils.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from io import BytesIO
+from PIL import Image
+import pytesseract
+
+
+def ocr_image(data: bytes) -> str:
+    """Return text recognized from an image using Tesseract."""
+    try:
+        img = Image.open(BytesIO(data))
+    except Exception:
+        return ""
+    try:
+        text = pytesseract.image_to_string(img)
+    except Exception:
+        return ""
+    return text.strip()

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -9,3 +9,4 @@ python-docx==1.2.0
 python-pptx==1.0.2
 ruff==0.12.0
 pillow==11.2.1
+pytesseract==0.3.10

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,7 +1,9 @@
 import os
+
 import fitz  # PyMuPDF
 import docx
 from pptx import Presentation
+from pptx.enum.shapes import MSO_SHAPE_TYPE
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain.embeddings import SentenceTransformerEmbeddings
 from langchain.vectorstores import FAISS
@@ -9,6 +11,8 @@ from langchain.llms import Ollama
 from langchain.chains import ConversationalRetrievalChain
 from langchain.memory import ConversationBufferMemory
 from langchain.schema import Document
+
+from .ocr_utils import ocr_image
 
 # Maximum number of tokens supported by the model.
 MAX_TOKENS = 8192
@@ -82,14 +86,19 @@ def load_txt(path: str) -> list[Document]:
 
 
 def load_pptx(path: str) -> list[Document]:
-    """Return the text content from a PowerPoint file."""
+    """Return the text and OCR'd image content from a PowerPoint file."""
     prs = Presentation(path)
     docs = []
     for i, slide in enumerate(prs.slides, start=1):
-        slide_text = []
+        slide_text: list[str] = []
         for shape in slide.shapes:
             if hasattr(shape, "text") and shape.text:
                 slide_text.append(shape.text)
+            if shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
+                img_bytes = shape.image.blob
+                img_text = ocr_image(img_bytes)
+                if img_text:
+                    slide_text.append(f"[Image text: {img_text}]")
         if slide_text:
             docs.append(
                 Document(page_content="\n".join(slide_text), metadata={"page": i})
@@ -98,14 +107,22 @@ def load_pptx(path: str) -> list[Document]:
 
 
 def load_pdf_with_password(path: str, password: str) -> list[Document]:
-    """Return the text from a PDF, unlocking it with the given password."""
+    """Return the text and OCR'd images from a PDF."""
     with fitz.open(path) as doc:
         if doc.needs_pass and not doc.authenticate(password):
             raise ValueError("Incorrect password")
-        docs = [
-            Document(page_content=page.get_text(), metadata={"page": i + 1})
-            for i, page in enumerate(doc)
-        ]
+        docs = []
+        for i, page in enumerate(doc, start=1):
+            text = page.get_text()
+            try:
+                pix = page.get_pixmap()
+                img_data = pix.tobytes("png")
+                img_text = ocr_image(img_data)
+                if img_text:
+                    text += f"\n[Image text: {img_text}]"
+            except Exception:
+                pass
+            docs.append(Document(page_content=text, metadata={"page": i}))
     return docs
 
 

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,0 +1,17 @@
+import io
+import pathlib
+import sys
+from PIL import Image, ImageDraw, ImageFont
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "app"))
+import ocr_utils
+
+def test_ocr_image_basic():
+    img = Image.new('RGB', (200, 80), color='white')
+    d = ImageDraw.Draw(img)
+    font = ImageFont.load_default()
+    d.text((10, 10), 'HELLO', font=font, fill='black')
+    buf = io.BytesIO()
+    img.save(buf, format='PNG')
+    text = ocr_utils.ocr_image(buf.getvalue())
+    assert 'HELLO' in text.upper()


### PR DESCRIPTION
## Summary
- support OCR via pytesseract for PDF and PPTX loaders
- install tesseract in the app image
- expose OCR helper in new `ocr_utils` module
- document new capability and dependency
- add regression test for OCR

## Testing
- `ruff check --quiet .`
- `python -m py_compile app/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c558740b88320b969b02abdff384e